### PR TITLE
`sendEvent` updates / version 2.0.0

### DIFF
--- a/API.md
+++ b/API.md
@@ -35,24 +35,32 @@ needed when the experiment is added to or removed from Test Pilot.
 
 Sends an event to the Mozilla data pipeline (and Google Analytics, if
 a `tid` was passed to the constructor). Note: to avoid breaking callers,
-if the required arguments are missing, an Error will not be thrown.
-Instead, the message will be silently dropped. Enable debug mode to
-see error messages.
+if sending the event fails, no Errors will be thrown. Instead, the message
+will be silently dropped, and, if debug mode is enabled, an error will be
+logged to the Browser Console.
 
-If you want to pass additional fields, or use a Google Analytics hit type
-other than 'event', you can transform the output yourself using the
-transform parameter. You will need to add Custom Dimensions to GA for any
-extra fields: <https://support.google.com/analytics/answer/2709828>
+If you want to pass extra fields to GA, or use a GA hit type other than
+`Event`, you can transform the output data object yourself using the
+`transform` parameter. You will need to add Custom Dimensions to GA for any
+extra fields: <https://support.google.com/analytics/answer/2709828>. Note
+that, by convention, the `variant` argument is mapped to the first Custom
+Dimension (`cd1`) when constructing the GA Event hit.
+
+Note: the data object format is currently different for each experiment,
+and should be defined based on the result of conversations with the Mozilla
+data team.
+
+A suggested default format is:
 
 **Parameters**
 
--   `$0.event` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** What is happening? e.g. `click`
--   `$0.object` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** What is being affected? e.g. `home-button-1`
+-   `$0.method` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** What is happening? e.g. `click`
+-   `$0.object` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** What is being affected? e.g. `home-button-1`
 -   `$0.category` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** If you want to add a category
     for easy reporting later. e.g. `mainmenu` (optional, default `interactions`)
 -   `$0.variant` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** An identifying string if you're running
     different variants. e.g. `cohort-A`
--   `$0.transform` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)?** Transform function used to alter the
+-   `transform` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)?** Transform function used to alter the
     parameters sent to GA. The `transform` function signature is
     `transform(input, output)`, where `input` is the object passed to
     `sendEvent` (excluding `transform`), and `output` is the default GA

--- a/examples/sdk/index.js
+++ b/examples/sdk/index.js
@@ -18,5 +18,5 @@ const btn = ui.ActionButton({
     '32': './icon-32.png',
     '64': './icon-64.png'
   },
-  onClick: () => sendEvent({object: 'sdk-button', event: 'click'})
+  onClick: () => sendEvent({object: 'sdk-button', method: 'click'})
 });

--- a/examples/webextension/background.js
+++ b/examples/webextension/background.js
@@ -10,6 +10,6 @@ browser.browserAction.onClicked.addListener((evt) => {
   console.log('Button clicked! Sending metrics event...');
   sendEvent({
     object: 'webext-button',
-    event: 'click'
+    method: 'click'
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testpilot-metrics",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Metrics library for Test Pilot experiments. Sends events to Google Analytics always, and Test Pilot metrics pipeline while the experiment is an active Test Pilot experiment.",
   "main": "testpilot-metrics.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -161,7 +161,7 @@ describe('sendEvent', () => {
       const m = new Metrics({id: '@my-addon', version: '1.0.2', uid: '12345'});
       const stub = sinon.stub(m, '_sendToClient');
 
-      m.sendEvent({event: 'click', object: 'button'});
+      m.sendEvent({method: 'click', object: 'button'});
       expect(stub.calledOnce).to.be.true;
 
       afterWebExt(global);
@@ -172,7 +172,7 @@ describe('sendEvent', () => {
       const clientStub = sinon.stub(m, '_sendToClient');
       const gaStub = sinon.stub(m, '_gaTransform');
 
-      m.sendEvent({event: 'click', object: 'button'});
+      m.sendEvent({method: 'click', object: 'button'});
       expect(gaStub.calledOnce).to.be.true;
 
       afterWebExt(global);
@@ -183,7 +183,7 @@ describe('sendEvent', () => {
       const clientStub = sinon.stub(m, '_sendToClient');
       const gaStub = sinon.stub(m, '_gaSend');
 
-      m.sendEvent({event: 'click', object: 'button'});
+      m.sendEvent({method: 'click', object: 'button'});
       expect(gaStub.calledOnce).to.be.true;
 
       afterWebExt(global);
@@ -194,7 +194,7 @@ describe('sendEvent', () => {
       const clientStub = sinon.stub(m, '_sendToClient');
       const gaStub = sinon.stub(m, '_gaTransform');
 
-      m.sendEvent({event: 'click', object: 'button'});
+      m.sendEvent({method: 'click', object: 'button'});
       expect(gaStub.calledOnce).to.be.false;
 
       afterWebExt(global);
@@ -205,7 +205,7 @@ describe('sendEvent', () => {
       const clientStub = sinon.stub(m, '_sendToClient');
       const gaStub = sinon.stub(m, '_gaSend');
 
-      m.sendEvent({event: 'click', object: 'button'});
+      m.sendEvent({method: 'click', object: 'button'});
       expect(gaStub.calledOnce).to.be.false;
 
       afterWebExt(global);
@@ -218,7 +218,7 @@ describe('_sendToClient', () => {
       const m = new Metrics({id: '@my-addon', version: '1.0.2', uid: '12345'});
       const postMessageStub = sinon.stub(m._channel, 'postMessage');
 
-      m.sendEvent({event: 'click', object: 'button'});
+      m.sendEvent({method: 'click', object: 'button'});
       expect(postMessageStub.calledOnce).to.be.true;
 
       afterWebExt(global);
@@ -228,15 +228,15 @@ describe('_sendToClient', () => {
       const m = new Metrics({id: '@my-addon', version: '1.0.2', uid: '12345'});
       const postMessageStub = sinon.stub(m._channel, 'postMessage');
 
-      m.sendEvent({event: 'click', object: 'button'});
-      expect(postMessageStub.withArgs({id: '@my-addon', event: 'click', object: 'button'}));
+      m.sendEvent({method: 'click', object: 'button'});
+      expect(postMessageStub.withArgs({id: '@my-addon', method: 'click', object: 'button'}));
     });
     it('should not serialize the packet before sending', () => {
       beforeWebExt(global);
       const m = new Metrics({id: '@my-addon', version: '1.0.2', uid: '12345'});
       const postMessageStub = sinon.stub(m._channel, 'postMessage');
 
-      m.sendEvent({event: 'click', object: 'button'});
+      m.sendEvent({method: 'click', object: 'button'});
       expect(typeof postMessageStub.getCall(0).args[0] !== 'string');
     });
   });
@@ -247,7 +247,7 @@ describe('_sendToClient', () => {
       global.Services.obs = { notifyObservers: notifyStub };
       const m = new Metrics({id: '@my-addon', version: '1.0.2', uid: '12345', type: 'sdk'});
 
-      m.sendEvent({event: 'click', object: 'button'});
+      m.sendEvent({method: 'click', object: 'button'});
       expect(notifyStub.calledOnce).to.be.true;
 
       afterSDK(global);
@@ -261,7 +261,7 @@ describe('_sendToClient', () => {
       global.Services.obs = { notifyObservers: notifyStub };
       const m = new Metrics({id: '@my-addon', version: '1.0.2', uid: '12345', type: 'bootstrapped'});
 
-      m.sendEvent({event: 'click', object: 'button'});
+      m.sendEvent({method: 'click', object: 'button'});
       expect(notifyStub.calledOnce).to.be.true;
 
       afterBootstrapped(global);


### PR DESCRIPTION
Change the `sendEvent` function signature:

- Old function signature: `sendEvent({event, object, category, variant,
  transform})`, where `event` and `object` were mandatory.

- New function signature: `sendEvent({method, object, category,
  variant}, transform)`, where:

  - `event` has been renamed to `method`

  - all fields in the data object (first `sendEvent` argument) are
    optional

  - `transform` has been removed from the data object, and is instead
    passed as an optional second argument to `sendEvent`.

Also fiddle with the docs, move object cloning out into a separate method, bump version number to 2.0.0.

Fixes #6.