### PR TITLE
Add eslint as a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "documentation": "^4.0.0-beta.18",
+    "eslint": "^3.14.1",
     "mocha": "^3.2.0",
     "mock-require": "^2.0.1",
     "sinon": "^1.17.7"


### PR DESCRIPTION
Ugh, I should have caught this before, but I have a globally installed **eslint** so it "just works" for me locally [although would implode upon itself when/if we add CI integration].